### PR TITLE
Add an option to output pretty json

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ end
 
 ### Specs
 
-desc "Build roda-route_list gem"
+desc "Run all specs"
 task :spec do |p|
   ENV['RUBY'] = FileUtils::RUBY
   ENV['RUBYLIB'] = "ENV['RUBYLIB']:lib"

--- a/bin/roda-parse_routes
+++ b/bin/roda-parse_routes
@@ -5,6 +5,7 @@ require 'json'
 require File.join(File.dirname(File.dirname(File.expand_path(__FILE__))), 'lib', 'roda-route_parser')
 
 file = $stdout
+json_gen_opts = {}
 options = OptionParser.new do |opts|
   opts.banner = "roda-parse_routes: Parse route comments from roda app files"
   opts.define_head "Usage: roda-parse_routes [options] [file] ..."
@@ -18,8 +19,12 @@ options = OptionParser.new do |opts|
   opts.on("-f", "--file ", "output to given file instead of stdout") do  |v|
     file = File.open(v, 'wb')
   end
+
+  opts.on("-p", "--pretty", "output pretty json (with indentation and newlines)") do
+    json_gen_opts = {:indent => '  ', :space => ' ', :object_nl => "\n", :array_nl => "\n"}
+  end
 end
 opts = options
 opts.parse!
 
-file.puts(RodaRouteParser.parse(ARGF).to_json)
+file.puts(RodaRouteParser.parse(ARGF).to_json(json_gen_opts))

--- a/spec/roda-route_list_spec.rb
+++ b/spec/roda-route_list_spec.rb
@@ -98,12 +98,29 @@ end
 
 describe 'roda-route_parser executable' do
   after do
-    File.delete "spec/routes-example.json"
+    %w[spec/routes-example.json spec/routes-example-pretty.json].each do |file|
+      begin
+        File.delete(file)
+      rescue Errno::ENOENT
+      end
+    end
   end
 
   it "should correctly parse the routes" do
     system(ENV['RUBY'] || 'ruby', "bin/roda-parse_routes", "-f", "spec/routes-example.json", "spec/routes.example")
     File.file?("spec/routes-example.json").must_equal true
     JSON.parse(File.read('spec/routes-example.json')).must_equal JSON.parse(File.read('spec/routes.json'))
+  end
+
+  it "should correctly write the pretty routes" do
+    system(ENV['RUBY'] || 'ruby', "bin/roda-parse_routes", "-f", "spec/routes-example-pretty.json", "-p", "spec/routes.example")
+    File.file?("spec/routes-example-pretty.json").must_equal true
+    File.read("spec/routes-example-pretty.json").must_equal(File.read("spec/routes-pretty.json"))
+  end
+
+  it "should correctly parse the pretty routes" do
+    system(ENV['RUBY'] || 'ruby', "bin/roda-parse_routes", "-f", "spec/routes-example-pretty.json", "-p", "spec/routes.example")
+    File.file?("spec/routes-example-pretty.json").must_equal true
+    JSON.parse(File.read('spec/routes-example-pretty.json')).must_equal JSON.parse(File.read('spec/routes.json'))
   end
 end

--- a/spec/routes-pretty.json
+++ b/spec/routes-pretty.json
@@ -1,0 +1,23 @@
+[
+  {
+    "path": "/foo"
+  },
+  {
+    "path": "/foo/bar",
+    "name": "bar"
+  },
+  {
+    "path": "/foo/baz",
+    "methods": [
+      "GET"
+    ]
+  },
+  {
+    "path": "/foo/baz/quux/:quux_id",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "name": "quux"
+  }
+]


### PR DESCRIPTION
Please consider adding an option ("-p") for pretty formatting of the generated JSON.  It helps with having viewable diffs of the generated JSON file (otherwise the diff compares two single-line files and the output is unreadable to mere humans).  The generated JSON file is usually parsed only once in production environments so the extra characters don't introduce any performance issue.

Thanks.