### PR TITLE
Raise different error on nil value

### DIFF
--- a/lib/roda/plugins/route_list.rb
+++ b/lib/roda/plugins/route_list.rb
@@ -77,8 +77,15 @@ class Roda
             if args.is_a?(Hash)
               range = 1..-1
               path = path.gsub(/:[^\/]+/) do |match|
-                unless value = args[match[range].to_sym]
+                key = match[range].to_sym
+                unless args.key?(key)
                   raise RodaError, "no matching value exists in the hash for named route #{name}: #{match}"
+                end
+
+                value = args[key]
+
+                if value.nil?
+                  raise RodaError, "nil value exists in the hash for named route #{name}: #{match}"
                 end
                 value
               end

--- a/spec/roda-route_list_spec.rb
+++ b/spec/roda-route_list_spec.rb
@@ -73,7 +73,13 @@ describe 'roda-route_list plugin' do
   end
 
   it ".listed_route should raise RodaError if there is no matching value when using a values hash" do
-    proc{@app.listed_route(:quux, {})}.must_raise(Roda::RodaError)
+    ex = proc{@app.listed_route(:quux, {})}.must_raise(Roda::RodaError)
+    ex.message.must_equal "no matching value exists in the hash for named route quux: :quux_id"
+  end
+
+  it ".listed_route should raise RodaError if provided value is nil when using a values hash" do
+    ex = proc{@app.listed_route(:quux, {quux_id: nil})}.must_raise(Roda::RodaError)
+    ex.message.must_equal "nil value exists in the hash for named route quux: :quux_id"
   end
 
   it ".listed_route should raise RodaError if there is no matching value when using a values array" do


### PR DESCRIPTION
If the hash provided to listed_route contains the key,
but the value for that key is nil, raise RodaError with
clear message.

Without this change, the error is slightly ambiguous.