### PR TITLE
Support brakets

### DIFF
--- a/lib/roda-route_parser.rb
+++ b/lib/roda-route_parser.rb
@@ -10,7 +10,7 @@ class RodaRouteParser
     end
 
     routes = []
-    regexp = /\A\s*#\s*route(?:\[(\w+)\])?:\s+(?:([A-Z|]+)?\s+)?(\S+)\s*\z/
+    regexp = /\A\s*#\s*route(?:\[([\w|\.|-]+)\])?:\s+(?:([A-Z|]+)?\s+)?(\S+)\s*\z/
     input.each_line do |line|
       if md = regexp.match(line)
         name, methods, route = md.captures

--- a/spec/roda-route_list_spec.rb
+++ b/spec/roda-route_list_spec.rb
@@ -55,7 +55,7 @@ describe 'roda-route_list plugin' do
       {:path=>'/foo'},
       {:path=>'/foo/bar', :name=>:bar},
       {:path=>'/foo/baz', :methods=>[:GET]},
-      {:path=>'/foo/baz/quux/:quux_id', :name=>:quux, :methods=>[:GET, :POST]},
+      {:path=>'/foo/baz/quux/{quux_id}', :name=>:quux, :methods=>[:GET, :POST]},
     ]
   end
 
@@ -68,7 +68,7 @@ describe 'roda-route_list plugin' do
 
   it ".listed_route should return path for route" do
     @app.listed_route(:bar).must_equal '/foo/bar'
-    @app.listed_route(:quux).must_equal '/foo/baz/quux/:quux_id'
+    @app.listed_route(:quux).must_equal '/foo/baz/quux/{quux_id}'
   end
 
   it ".listed_route should return path for route when given a values hash" do

--- a/spec/routes-pretty.json
+++ b/spec/routes-pretty.json
@@ -13,7 +13,7 @@
     ]
   },
   {
-    "path": "/foo/baz/quux/:quux_id",
+    "path": "/foo/baz/quux/{quux_id}",
     "methods": [
       "GET",
       "POST"

--- a/spec/routes.example
+++ b/spec/routes.example
@@ -8,5 +8,5 @@ foo
   #route:   GET   /foo/baz  
   baz
 
-    #  route[quux]: GET|POST /foo/baz/quux/:quux_id
+    #  route[quux]: GET|POST /foo/baz/quux/{quux_id}
     quux

--- a/spec/routes.json
+++ b/spec/routes.json
@@ -1,1 +1,1 @@
-[{"path":"/foo"},{"path":"/foo/bar","name":"bar"},{"path":"/foo/baz","methods":["GET"]},{"path":"/foo/baz/quux/:quux_id","methods":["GET","POST"],"name":"quux"}]
+[{"path":"/foo"},{"path":"/foo/bar","name":"bar"},{"path":"/foo/baz","methods":["GET"]},{"path":"/foo/baz/quux/{quux_id}","methods":["GET","POST"],"name":"quux"}]


### PR DESCRIPTION
We already changed the `route_list` plugin to support dots. In order to be compatible with the [front-end library](https://github.com/tighten/ziggy#the-router-class) we are using for routes we need to support brakets in arguments.

```
/onboarding/:code/about-you
```

Becomes:

```
/onboarding/{onboarding}/about-you
```

I manually tested the regex and it works, could you please test the plugin and let me know if can work this way?